### PR TITLE
Changed regexes to allow two spaces between "83" and "Linux" in fdisk…

### DIFF
--- a/raspbian-shrink/raspbian-shrink
+++ b/raspbian-shrink/raspbian-shrink
@@ -109,8 +109,8 @@ umount "$MOUNTPOINT" 2>/dev/null; losetup -d /dev/loop0 2>/dev/null; rmdir "$MOU
 
 echo "  ***** Checking image *****"
 CHECK1=`fdisk -l "$1" | sed -nr "s/^\S+1\s+([0-9]+).*$/\1/p"`
-START=`fdisk -l "$1" | sed -nr "s/^\S+2\s+([0-9]+).* 83 Linux$/\1/p"`
-SIZE=`fdisk -l "$1" | sed -nr "s/^\S+2\s+[0-9]+\s+[0-9]+\s+([0-9]+).* 83 Linux$/\1/p"`
+START=`fdisk -l "$1" | sed -nr "s/^\S+2\s+([0-9]+).* 83\s+Linux$/\1/p"`
+SIZE=`fdisk -l "$1" | sed -nr "s/^\S+2\s+[0-9]+\s+[0-9]+\s+([0-9]+).* 83\s+Linux$/\1/p"`
 CHECK3=`fdisk -l "$1" | sed -nr "s/^\S+3\s+([0-9]+).*$/\1/p"`
 if [ "$START" == "" ] || [ ! "$CHECK3" == "" ]; then
   echo "File '$1' doesn't look like a Raspbian image file."


### PR DESCRIPTION
… output.

fdisk on Ubuntu 14.04.3 places two spaces between "83" and "Linux" (see example below).  I modified the regexes for extracting $START and $SIZE to match multiple spaces in that position instead of just one.

```
ross@ubuntu:~/devl$ fdisk -l "/media/psf/Downloads/ic-widpatcon_shrunk_20170921.img"

Disk /media/psf/Downloads/ic-widpatcon_shrunk_20170921.img: 7948 MB, 7948206080 bytes
255 heads, 63 sectors/track, 966 cylinders, total 15523840 sectors
Units = sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disk identifier: 0x66b52cf6

                                                Device Boot      Start         End      Blocks   Id  System
/media/psf/Downloads/ic-widpatcon_shrunk_20170921.img1            8192       93813       42811    c  W95 FAT32 (LBA)
/media/psf/Downloads/ic-widpatcon_shrunk_20170921.img2           94208    15523839     7714816   83  Linux
ross@ubuntu:~/devl$ 
```
