### PR TITLE
raspbian-shrink : Fixing eventual conflicts with snap applications

### DIFF
--- a/raspbian-shrink/raspbian-shrink
+++ b/raspbian-shrink/raspbian-shrink
@@ -105,8 +105,11 @@ if [ ! "$OVERWRITE" ] && [ -e "$MOUNTPOINT" ]; then
   exit -7
 fi
 
+# Get an available loopback device
+LOOPDEVICE=$(losetup -f)
+
 # Clear down the mount point
-umount "$MOUNTPOINT" 2>/dev/null; losetup -d /dev/loop0 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
+umount "$MOUNTPOINT" 2>/dev/null; losetup -d $LOOPDEVICE 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
 
 echo "  ***** Checking image *****"
 CHECK1=`fdisk -l "$1" | sed -nr "s/^\S+1\s+([0-9]+).*$/\1/p"`
@@ -140,14 +143,14 @@ else
 fi
 
 echo "  ***** Mounting filesystem to examine free space *****"
-losetup /dev/loop0 "$OUTFILE" -o $(($START*512))
-mkdir -p "$MOUNTPOINT" ; mount /dev/loop0 "$MOUNTPOINT"
-MINSIZE=`df -m | sed -nr "s/^\/dev\/loop0\s+[0-9]+\s+([0-9]+).*$/\1/p"`
+losetup $LOOPDEVICE "$OUTFILE" -o $(($START*512))
+mkdir -p "$MOUNTPOINT" ; mount $LOOPDEVICE "$MOUNTPOINT"
+MINSIZE=`df -m | sed -nr "s/^\/dev\/loop$(echo $LOOPDEVICE | sed -nr "s/\/dev\/loop//p")\s+[0-9]+\s+([0-9]+).*$/\1/p"`
 umount "$MOUNTPOINT"
 NEWSIZE=$((($MINSIZE+$FREESPACE)*2048))
 if [ "$SIZE" -le "$NEWSIZE" ]; then
   if [ ! "$OVERWRITE" ]; then
-    losetup -d /dev/loop0 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
+    losetup -d $LOOPDEVICE 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
     echo "'$OUTFILE' has $FREESPACE MB or less free."
     echo "Image can't be shrunk any further."
     echo "Maybe this is an image you've already shrunk?"
@@ -155,52 +158,52 @@ if [ "$SIZE" -le "$NEWSIZE" ]; then
     exit -9
   else
     if [ "$SIZE" -eq "$NEWSIZE" ]; then
-      losetup -d /dev/loop0 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
+      losetup -d $LOOPDEVICE 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
       echo "'$OUTFILE' already has exactly $FREESPACE MB free."
       echo "Nothing to do."
       exit -9
     fi
     echo "  ***** Unmounting then padding image to add more free space *****"
-    losetup -d /dev/loop0 2>/dev/null;
+    losetup -d $LOOPDEVICE 2>/dev/null;
     dcfldd statusinterval=16 if=/dev/zero bs=1M count=$((($NEWSIZE-$SIZE+2048)/2048)) >>"$OUTFILE"
     echo "  ***** Remounting *****"
-    losetup /dev/loop0 "$OUTFILE" -o $(($START*512))
+    losetup $LOOPDEVICE "$OUTFILE" -o $(($START*512))
   fi
 fi
 
 echo "  ***** Checking filesystem *****"
-e2fsck -fy /dev/loop0
+e2fsck -fy $LOOPDEVICE
 if [ $? -ne 0 ]; then
-  losetup -d /dev/loop0 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
+  losetup -d $LOOPDEVICE 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
   echo "fsck failed. Check if the image is corrupt, e.g. partial download."
   exit -10
 fi
 
 echo "  ***** Resizing filesystem *****"
-resize2fs -f /dev/loop0 $(($MINSIZE+$FREESPACE))M
+resize2fs -f $LOOPDEVICE $(($MINSIZE+$FREESPACE))M
 if [ $? -ne 0 ]; then
-  losetup -d /dev/loop0 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
+  losetup -d $LOOPDEVICE 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
   echo "resize2fs failed. Good luck with that."
   exit -11
 fi
-losetup -d /dev/loop0
+losetup -d $LOOPDEVICE
 echo -e "p\nd\n2\nn\np\n2\n$START\n+$NEWSIZE\np\nw\n" | fdisk "$OUTFILE"
 END=`fdisk -l "$OUTFILE" | sed -nr "s/^\S+\.img2\s+[0-9]+\s+([0-9]+).*$/\1/p"`
 
 echo "  ***** Truncating image *****"
 truncate -s $((($END+1)*512)) "$OUTFILE"
 
-losetup /dev/loop0 "$OUTFILE" -o $(($START*512))
-mount /dev/loop0 "$MOUNTPOINT"
+losetup $LOOPDEVICE "$OUTFILE" -o $(($START*512))
+mount $LOOPDEVICE "$MOUNTPOINT"
 if [ $? -ne 0 ]; then
-  umount "$MOUNTPOINT" ; rmdir "$MOUNTPOINT" ; losetup -d /dev/loop0
+  umount "$MOUNTPOINT" ; rmdir "$MOUNTPOINT" ; losetup -d $LOOPDEVICE
   echo "Something went badly wrong. Can't mount the truncated image."
   echo "Look for error messages above."
   exit -12
 fi
 
 echo "  ***** Renaming filesystem *****"
-e2label /dev/loop0 "$LABEL"
+e2label $LOOPDEVICE "$LABEL"
 if [ $? -ne 0 ]; then
   echo "e2label failed. Unable to rename filesystem."
   exit -13
@@ -209,7 +212,7 @@ fi
 echo "  ***** Zero-filling free space *****"
 dcfldd if=/dev/zero of="$MOUNTPOINT"/zero.txt
 rm "$MOUNTPOINT"/zero.txt
-umount "$MOUNTPOINT" 2>/dev/null; losetup -d /dev/loop0 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
+umount "$MOUNTPOINT" 2>/dev/null; losetup -d $LOOPDEVICE 2>/dev/null; rmdir "$MOUNTPOINT" 2>/dev/null;
 
 # As this is run by sudo, the output gets owned by root.
 # This isn't usually what is desired. So let's try to fix that by guessing


### PR DESCRIPTION
Hello!
I was about to use the raspbian-shrink script on my (almost) brand new Ubuntu 18.04 installation.
But I figured out I had some problems with the loop device, with "df" command, I noticed that plenty of loop devices were used for snap applications in Ubuntu.
Therefore /dev/loop0 is no more available and cannot be used as the script does.
So I replaced all hard coded  "/dev/loop0" occurrences with a variable initialized to the first available loop device.